### PR TITLE
Send run-query and get-tx-status-request multiple times and aggregate the results

### DIFF
--- a/services/proxy/get_transaction_status_handler.go
+++ b/services/proxy/get_transaction_status_handler.go
@@ -17,14 +17,27 @@ func getTransactionStatus(h *handler, data []byte) (input membuffers.Message, ou
 	h.logger.Info("received request", log.Stringable("request", input))
 
 	shuffledEndpoints := h.getShuffledEndpoints()
-	res, resBody, e := h.transport.Send(shuffledEndpoints[0], h.path, data)
-	if e != nil {
-		return input, nil, &HttpErr{http.StatusBadRequest, log.Error(e), e.Error()}
-	}
+	response := filterResponsesByBlockHeight(aggregateRequest(REQUEST_ATTEMPTS, shuffledEndpoints, func(endpoint string) response {
+		res, resBody, e := h.transport.Send(shuffledEndpoints[0], h.path, data)
+		if e != nil {
+			return response{
+				httpErr: &HttpErr{http.StatusBadRequest, log.Error(e), e.Error()},
+			}
+		}
 
-	if res.StatusCode != http.StatusOK {
-		return input, nil, &HttpErr{res.StatusCode, log.Error(errors.New(res.Status)), res.Header.Get("X-ORBS-ERROR-DETAILS")}
-	}
+		if res.StatusCode != http.StatusOK {
+			return response{
+				httpErr: &HttpErr{res.StatusCode, log.Error(errors.New(res.Status)), res.Header.Get("X-ORBS-ERROR-DETAILS")},
+			}
+		}
 
-	return input, client.GetTransactionStatusResponseReader(resBody), &HttpErr{Code: res.StatusCode}
+		reader := client.GetTransactionStatusResponseReader(resBody)
+		return response{
+			output:        reader,
+			requestResult: reader.RequestResult(),
+			httpErr:       &HttpErr{Code: res.StatusCode},
+		}
+	}))
+
+	return input, response.output, response.httpErr
 }

--- a/services/proxy/get_transaction_status_handler.go
+++ b/services/proxy/get_transaction_status_handler.go
@@ -15,7 +15,9 @@ func getTransactionStatus(h *handler, data []byte) (input membuffers.Message, ou
 	}
 
 	h.logger.Info("received request", log.Stringable("request", input))
-	res, resBody, e := h.transport.SendRandom(h.config.Endpoints, h.path, data)
+
+	shuffledEndpoints := h.getShuffledEndpoints()
+	res, resBody, e := h.transport.Send(shuffledEndpoints[0], h.path, data)
 	if e != nil {
 		return input, nil, &HttpErr{http.StatusBadRequest, log.Error(e), e.Error()}
 	}

--- a/services/proxy/handlers.go
+++ b/services/proxy/handlers.go
@@ -6,7 +6,9 @@ import (
 	"github.com/orbs-network/orbs-spec/types/go/protocol/client"
 	"github.com/orbs-network/scribe/log"
 	"github.com/orbs-network/trash-panda/transport"
+	"math/rand"
 	"net/http"
+	"time"
 )
 
 type Handler interface {
@@ -78,6 +80,17 @@ func (h *handler) Path() string {
 
 func (h *handler) Handle(data []byte) (input membuffers.Message, output membuffers.Message, err *HttpErr) {
 	return h.f(h, data)
+}
+
+func (h *handler) getShuffledEndpoints() []string {
+	shuffled := make([]string, len(h.config.Endpoints))
+	copy(shuffled, h.config.Endpoints)
+
+	random := rand.New(rand.NewSource(time.Now().UnixNano()))
+	random.Shuffle(len(shuffled), func(i, j int) {
+		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+	})
+	return shuffled
 }
 
 func (s *service) wrapHandler(h Handler) http.HandlerFunc {

--- a/services/proxy/handlers_test.go
+++ b/services/proxy/handlers_test.go
@@ -1,0 +1,44 @@
+package proxy
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_aggregateAndFilter(t *testing.T) {
+	endpoints := []string{"a", "b", "c", "d"}
+
+	results := aggregateRequest(4, endpoints, func(endpoint string) response {
+		switch endpoint {
+		case "b":
+			return response{
+				blockHeight: 3,
+			}
+		case "c":
+			return response{
+				blockHeight: 4,
+			}
+		case "d":
+			return response{
+				blockHeight: 4,
+			}
+		default:
+			return response{
+				blockHeight: 0,
+				httpErr: &HttpErr{
+					Message: "timeout",
+				},
+			}
+		}
+	})
+
+	require.Len(t, results, 4)
+
+	require.EqualValues(t, 0, results[0].blockHeight)
+	require.EqualValues(t, 3, results[1].blockHeight)
+	require.EqualValues(t, 4, results[2].blockHeight)
+	require.EqualValues(t, 4, results[3].blockHeight)
+
+	result := filterResponses(results)
+	require.EqualValues(t, 4, result.blockHeight)
+}

--- a/services/proxy/handlers_test.go
+++ b/services/proxy/handlers_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"github.com/orbs-network/orbs-spec/types/go/protocol/client"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
@@ -12,19 +13,18 @@ func Test_aggregateAndFilter(t *testing.T) {
 		switch endpoint {
 		case "b":
 			return response{
-				blockHeight: 3,
+				requestResult: (&client.RequestResultBuilder{BlockHeight: 3}).Build(),
 			}
 		case "c":
 			return response{
-				blockHeight: 4,
+				requestResult: (&client.RequestResultBuilder{BlockHeight: 4}).Build(),
 			}
 		case "d":
 			return response{
-				blockHeight: 4,
+				requestResult: (&client.RequestResultBuilder{BlockHeight: 4}).Build(),
 			}
 		default:
 			return response{
-				blockHeight: 0,
 				httpErr: &HttpErr{
 					Message: "timeout",
 				},
@@ -34,11 +34,11 @@ func Test_aggregateAndFilter(t *testing.T) {
 
 	require.Len(t, results, 4)
 
-	require.EqualValues(t, 0, results[0].blockHeight)
-	require.EqualValues(t, 3, results[1].blockHeight)
-	require.EqualValues(t, 4, results[2].blockHeight)
-	require.EqualValues(t, 4, results[3].blockHeight)
+	require.Nil(t, results[0].requestResult)
+	require.EqualValues(t, 3, results[1].requestResult.BlockHeight())
+	require.EqualValues(t, 4, results[2].requestResult.BlockHeight())
+	require.EqualValues(t, 4, results[3].requestResult.BlockHeight())
 
-	result := filterResponses(results)
-	require.EqualValues(t, 4, result.blockHeight)
+	result := filterResponsesByBlockHeight(results)
+	require.EqualValues(t, 4, result.requestResult.BlockHeight())
 }

--- a/services/proxy/run_query_handler.go
+++ b/services/proxy/run_query_handler.go
@@ -17,7 +17,7 @@ func runQuery(h *handler, data []byte) (input membuffers.Message, output membuff
 	h.logger.Info("received request", log.Stringable("request", input))
 
 	shuffledEndpoints := h.getShuffledEndpoints()
-	response := filterResponses(aggregateRequest(3, shuffledEndpoints, func(endpoint string) response {
+	response := filterResponsesByBlockHeight(aggregateRequest(REQUEST_ATTEMPTS, shuffledEndpoints, func(endpoint string) response {
 		res, resBody, e := h.transport.Send(shuffledEndpoints[0], h.path, data)
 		if e != nil {
 			return response{
@@ -33,9 +33,9 @@ func runQuery(h *handler, data []byte) (input membuffers.Message, output membuff
 
 		reader := client.RunQueryResponseReader(resBody)
 		return response{
-			output:      reader,
-			httpErr:     &HttpErr{Code: res.StatusCode},
-			blockHeight: uint64(reader.RequestResult().BlockHeight()),
+			output:        reader,
+			httpErr:       &HttpErr{Code: res.StatusCode},
+			requestResult: reader.RequestResult(),
 		}
 	}))
 	return input, response.output, response.httpErr

--- a/services/proxy/run_query_handler.go
+++ b/services/proxy/run_query_handler.go
@@ -16,7 +16,8 @@ func runQuery(h *handler, data []byte) (input membuffers.Message, output membuff
 
 	h.logger.Info("received request", log.Stringable("request", input))
 
-	res, resBody, e := h.transport.SendRandom(h.config.Endpoints, h.path, data)
+	shuffledEndpoints := h.getShuffledEndpoints()
+	res, resBody, e := h.transport.Send(shuffledEndpoints[0], h.path, data)
 	if e != nil {
 		return input, nil, &HttpErr{http.StatusBadRequest, log.Error(e), e.Error()}
 	}

--- a/services/proxy/send_transaction_async_handler.go
+++ b/services/proxy/send_transaction_async_handler.go
@@ -17,7 +17,8 @@ func sendTransactionAsync(h *handler, data []byte) (input membuffers.Message, ou
 
 	h.logger.Info("received request", log.Stringable("request", input))
 
-	res, resBody, e := h.transport.SendRandom(h.config.Endpoints, h.path, data)
+	shuffledEndpoints := h.getShuffledEndpoints()
+	res, resBody, e := h.transport.Send(shuffledEndpoints[0], h.path, data)
 	if e != nil {
 		output = (&client.SendTransactionResponseBuilder{
 			TransactionStatus: protocol.TRANSACTION_STATUS_PENDING,

--- a/services/proxy/send_transaction_handler.go
+++ b/services/proxy/send_transaction_handler.go
@@ -17,7 +17,8 @@ func sendTransaction(h *handler, data []byte) (input membuffers.Message, output 
 
 	h.logger.Info("received request", log.Stringable("request", input))
 
-	res, resBody, e := h.transport.SendRandom(h.config.Endpoints, h.path, data)
+	shuffledEndpoints := h.getShuffledEndpoints()
+	res, resBody, e := h.transport.Send(shuffledEndpoints[0], h.path, data)
 	if e != nil {
 		output = (&client.SendTransactionResponseBuilder{
 			TransactionStatus: protocol.TRANSACTION_STATUS_PENDING,

--- a/transport/http_transport.go
+++ b/transport/http_transport.go
@@ -6,7 +6,6 @@ import (
 	"github.com/orbs-network/orbs-client-sdk-go/orbs"
 	"github.com/pkg/errors"
 	"io/ioutil"
-	"math/rand"
 	"net/http"
 	"time"
 )
@@ -65,17 +64,4 @@ func (t *httpTransport) Send(endpoint string, path string, payload []byte) (*htt
 	}
 
 	return res, buf, nil
-}
-
-func (t *httpTransport) SendRandom(endpoints []string, path string, payload []byte) (*http.Response, []byte, error) {
-	if len(endpoints) == 0 {
-		return nil, nil, errors.New("no endpoints were provided to HttpTransport")
-	}
-
-	return t.Send(t.getRandomEndpoint(endpoints), path, payload)
-}
-
-func (t *httpTransport) getRandomEndpoint(endpoints []string) string {
-	random := rand.New(rand.NewSource(time.Now().UnixNano()))
-	return endpoints[random.Intn(len(endpoints))]
 }

--- a/transport/mock_transport.go
+++ b/transport/mock_transport.go
@@ -30,10 +30,6 @@ func (t *MockTransport) Send(endpoint string, path string, payload []byte) (*htt
 	return nil, nil, errors.New("failed to send payload")
 }
 
-func (t *MockTransport) SendRandom(endpoints []string, path string, payload []byte) (*http.Response, []byte, error) {
-	return t.Send(endpoints[0], path, payload)
-}
-
 func (t *MockTransport) On() {
 	t.on = true
 }

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -4,5 +4,4 @@ import "net/http"
 
 type Transport interface {
 	Send(endpoint string, path string, payload []byte) (*http.Response, []byte, error)
-	SendRandom(endpoints []string, path string, payload []byte) (*http.Response, []byte, error)
 }


### PR DESCRIPTION
Send stateless requests to multiple nodes to ensure availability even if some nodes of the network are down at the moment.